### PR TITLE
Fix MissingParameter error by converting output_file to an Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python-cath --help
 ```
 
 ```bash
-python-cath file1 file2 outfile
+python-cath file1 file2 --output outfile
 ```
 
 or if installed with `Poetry`:
@@ -44,7 +44,7 @@ poetry run python-cath --help
 ```
 
 ```bash
-poetry run python-cath file1 file2 outfile
+poetry run python-cath file1 file2 --output outfile
 ```
 
 ### Makefile usage

--- a/python_cath/__main__.py
+++ b/python_cath/__main__.py
@@ -29,7 +29,9 @@ def version_callback(value: bool) -> None:
 @app.command()
 def main(
     file_list: List[str] = typer.Argument(...),
-    output_file: str = typer.Option(..., "--output", "-o", help="Output file path"),
+    output_file: str = typer.Option(
+        ..., "--output", "-o", help="Output file path"
+    ),
 ) -> None:
     """Concatenate CSV files with a shared header into output_file."""
     concat(file_list, output_file)

--- a/python_cath/__main__.py
+++ b/python_cath/__main__.py
@@ -11,6 +11,8 @@ app = typer.Typer(
     name="python-cath",
     help="Cat files w/ headers",
     add_completion=False,
+    invoke_without_command=True,
+    no_args_is_help=True,
 )
 console = Console()
 

--- a/python_cath/__main__.py
+++ b/python_cath/__main__.py
@@ -27,7 +27,7 @@ def version_callback(value: bool) -> None:
 @app.command()
 def main(
     file_list: List[str] = typer.Argument(...),
-    output_file: str = typer.Argument(...),
+    output_file: str = typer.Option(..., "--output", "-o", help="Output file path"),
 ) -> None:
     """Concatenate CSV files with a shared header into output_file."""
     concat(file_list, output_file)


### PR DESCRIPTION
Using two positional Arguments where the first is a List[str] causes
Click/Typer to consume all args into file_list, leaving nothing for
output_file. Making output_file an --output/-o option resolves this.

https://claude.ai/code/session_01HPWiMpB9gzLqvTnjgXoe9J